### PR TITLE
fix XML convertion by properly escaping XML

### DIFF
--- a/src/Clearvox/Gigaset/Provision/Config.php
+++ b/src/Clearvox/Gigaset/Provision/Config.php
@@ -9,6 +9,8 @@ namespace Clearvox\Gigaset\Provision;
  */
 class Config
 {
+    use XMLHelper;
+
     /**
      * @var string
      */
@@ -311,19 +313,19 @@ class Config
     public function toXML()
     {
         $output = '<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL;
-        $output .= '<provisioning version="1.1" productID="' . $this->getProductID() . '">' . PHP_EOL;
+        $output .= '<provisioning version="1.1" productID="' . xml_escape($this->getProductID()) . '">' . PHP_EOL;
 
         $output .= '<firmware>' . PHP_EOL;
 
         if ($this->getFirmware()) {
-            $output .= '<file version="' . $this->getFirmware()->getVersion() . '" url="' . $this->getFirmware()->getUrl() . '"/>' . PHP_EOL;
+            $output .= '<file version="' . xml_escape($this->getFirmware()->getVersion()) . '" url="' . xml_escape($this->getFirmware()->getUrl()) . '"/>' . PHP_EOL;
         }
 
         $output .= '</firmware>' . PHP_EOL;
 
         if ($this->getDownloadWallpaper()) {
             $output .= '<custom>' . PHP_EOL;
-            $output .= '<step type="DownloadWallpaper" url="' . $this->getDownloadWallpaper() . '"/>' . PHP_EOL;
+            $output .= '<step type="DownloadWallpaper" url="' . xml_escape($this->getDownloadWallpaper()) . '"/>' . PHP_EOL;
             $output .= '</custom>' . PHP_EOL;
         }
 
@@ -341,7 +343,7 @@ class Config
                 $leafValue = $leafValue ? '1' : '0';
             }
 
-            $output .= '<param name="' . join('.', $keys) . '" value="' . $leafValue . '" />' . PHP_EOL;
+            $output .= '<param name="' . xml_escape(join('.', $keys)) . '" value="' . xml_escape($leafValue) . '" />' . PHP_EOL;
         }
         $output .= '</nvm>' . PHP_EOL;
 

--- a/src/Clearvox/Gigaset/Provision/XMLHelper.php
+++ b/src/Clearvox/Gigaset/Provision/XMLHelper.php
@@ -1,0 +1,15 @@
+<?php
+namespace Clearvox\Gigaset\Provision;
+
+trait XMLHelper
+{
+    /**
+     * @param string $input
+     * @returns $string
+     */
+    function xml_escape($input) {
+        // Convert special characters to their respective XML entities
+        // implementation based on https://ssojet.com/escaping/xml-escaping-in-php/
+        return htmlspecialchars($input, ENT_XML1, 'UTF-8');
+    }
+}


### PR DESCRIPTION
This should [fix those core tests that randomly fail](https://github.com/clearvox/core/runs/48311145859). We can make those tests to fail always (without this code change) by using `$user->setFirstName($user->getFirstName() . 'ë');` in the [testGigasetProvisioning function ](https://github.com/clearvox/core/blob/release/2.7.0/server/web/tests/Components/Provisioning/ClearvoxProvisioning/GigasetProvisioningTest.php#L70)